### PR TITLE
[hotfix] Fix tar option.

### DIFF
--- a/0_11_14/Dockerfile
+++ b/0_11_14/Dockerfile
@@ -3,6 +3,4 @@ FROM hashicorp/terraform:0.11.14
 ENV TFNOTIFY=0.3.0
 
 RUN curl -sL https://github.com/mercari/tfnotify/releases/download/v${TFNOTIFY}/tfnotify_v${TFNOTIFY}_linux_amd64.tar.gz |\
-    tar zxvf -C /tmp && \
-    cp /tmp/tfnotify_v${TFNOTIFY}_linux_amd64/tfnotify /usr/local/bin/tfnotify && \
-    rm -rf /tmp/*
+    tar zx -C /tmp && cp /tmp/tfnotify_v${TFNOTIFY}_linux_amd64/tfnotify /usr/local/bin/tfnotify && rm -rf /tmp/*


### PR DESCRIPTION
- fix error for tar options.
  - https://cloud.docker.com/u/campfirejp/repository/docker/campfirejp/docker-terraform-tfnotify/builds/7c142c1d-64a7-4a25-90ec-6ac26e7b957d

```
Step 3/3 : RUN curl -sL https://github.com/mercari/tfnotify/releases/download/v${TFNOTIFY}/tfnotify_v${TFNOTIFY}_linux_amd64.tar.gz | tar zxvf -C /tmp && cp /tmp/tfnotify_v${TFNOTIFY}_linux_amd64/tfnotify /usr/local/bin/tfnotify && rm -rf /tmp/*
---> Running in 0094ef1e5c40
tar: can't open '-C': No such file or directory
```