### PR TITLE
change docker container registry from docker hub to amazon public ecr

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -2,7 +2,7 @@ name: master workflow
 
 on:
   push:
-    branches: [ feature/add-github-actions ]
+    branches: [ master ]
 
 jobs:
   build_and_push_to_publicecr:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -2,12 +2,32 @@ name: master workflow
 
 on:
   push:
-    branches: [ master ]
+    branches: [ feature/add-github-actions ]
 
 jobs:
-  build_and_push_to_publicecr:
+  setup:
     runs-on: ubuntu-latest
-    name: build_and_push_to_publicecr
+    name: setup
+    outputs:
+      directories: ${{ steps.set-directories.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: get directories
+        id: set-directories
+        run: |
+          results="[\"$(ls | grep -E "[0-9]{1,2}_[0-9]{1,2}_[0-9]{1,2}"  | tr '\n' ',' | sed -e 's/,$/\n/g' | sed -e 's/,/\",\"/g')\"]"
+          list=$(echo $results | jq -c)
+          echo "::set-output name=value::${list}"
+
+  build_and_push:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        directories: ${{fromJson(needs.setup.outputs.directories)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,9 +45,6 @@ jobs:
           ECR_REPOSITORY: terraform-circleci-base-image
         run: |
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_REGISTRY
-          results=$(ls | grep -E "[0-9]{1,2}_[0-9]{1,2}_[0-9]{1,2}")
-          for v in ${results[@]}; do
-            version=$(echo ${v} | sed -e s/_/./g)
-            docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${version} ./${v}/
-            docker push $ECR_REGISTRY/$ECR_REPOSITORY:${version}
-          done
+          version=$(echo ${{ matrix.directories }} | sed -e s/_/./g)
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${version} ./${{ matrix.directories }}/
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${version}

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,0 +1,33 @@
+name: master workflow
+
+on:
+  push:
+    branches: [ feature/add-github-actions ]
+
+jobs:
+  build_and_push_to_publicecr:
+    runs-on: ubuntu-latest
+    name: build_and_push_to_publicecr
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Build, tag, and push image to Amazon PublicECR
+        env:
+          ECR_REGISTRY: public.ecr.aws/f1m7u9r1
+          ECR_REPOSITORY: terraform-circleci-base-image
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_REGISTRY
+          results=$(ls | grep -E "[0-9]{1,2}_[0-9]{1,2}_[0-9]{1,2}")
+          for v in ${results[@]}; do
+            version=$(echo ${v} | sed -e s/_/./g)
+            docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${version} ./${v}/
+            docker push $ECR_REGISTRY/$ECR_REPOSITORY:${version}
+          done

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -2,7 +2,7 @@ name: master workflow
 
 on:
   push:
-    branches: [ feature/add-github-actions ]
+    branches: [ master ]
 
 jobs:
   setup:


### PR DESCRIPTION
## 内容
docker hubからaws public ecrにコンテナ置き場を変更する
→そのために、github actions内でbuildして、pushする

## 申し送り
- ecrの場合は、github actionsのlibrary的なものがあるのですが、ecr publicはないので、scriptで書いています
- ( https://github.com/campfire-inc/docker-terraform-tfnotify/actions )にてテスト実行して、正常にPushされることを確認済みです
- 各verのディレクトリごとにimageをbuildし、○.○.○という形でイメージがpushされるようになっています。
    - ex: 0_11_14ディレクトリの場合、0.11.14というタグが付きます。
