### PR TITLE
add curl in docker image for v0.11.15

### DIFF
--- a/0_11_15/Dockerfile
+++ b/0_11_15/Dockerfile
@@ -1,5 +1,7 @@
 FROM hashicorp/terraform:0.11.15
 
+RUN apk upgrade && apk add curl
+
 ENV TFNOTIFY=0.3.0
 
 RUN curl -sL https://github.com/mercari/tfnotify/releases/download/v${TFNOTIFY}/tfnotify_v${TFNOTIFY}_linux_amd64.tar.gz |\


### PR DESCRIPTION
v0.11.15 のイメージに curl がなかったので、修正する.